### PR TITLE
feat: add full_path parameter

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -88,10 +88,14 @@ async function run(): Promise<void> {
     slugAsFolderName === true && attributes[slugKey]
       ? attributes[slugKey]
       : String(issue.number)
-  const fullPath = path.join(destPath, folderName, `index${extension}`)
+  const fullPath =
+    attributes['full_path'] ||
+    path.join(destPath, folderName, `index${extension}`)
   const dirname = path.dirname(fullPath)
-  fs.rmSync(dirname, {recursive: true, force: true})
-  mkdirp.sync(dirname)
+
+  if (!fs.existsSync(dirname)) {
+    mkdirp.sync(dirname)
+  }
 
   let bodyText = bodyWithoutFrontMatter
   const images = extractImages(bodyText)


### PR DESCRIPTION
안녕하세요 😄
[#13](https://github.com/eunjae-lee/issue-to-markdown/pull/13) 에서 말씀주신 것처럼 `full_path`라는 `matter`가  issue에 있으면 
폴더를 생성하고 파일을 만드는 것으로 변경했습니다! 
[로컬에서 실행한 결과](https://github.com/youngkyo0504/test/actions/runs/4517115766) 잘 동작하는 것을 확인할 수 있었습니다 👍 

더 추가하고 싶었던 것은 READ.md 파일에 해당 정보를 넣고 싶은데 어디에 넣어야할지 잘 모르겠네요ㅜ 
혹시 이부분만 따로 추가해주실 수 있을까요?
