### PR TITLE
feat: Convert buffer image to PNG format

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "download": "^8.0.0",
     "gray-matter": "^4.0.3",
     "mkdirp": "^2.1.3",
+    "sharp": "^0.33.1",
     "yaml": "^2.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@actions/github": "^5.1.1",
     "dayjs": "^1.11.7",
     "download": "^8.0.0",
+    "file-type": "^19.0.0",
     "gray-matter": "^4.0.3",
     "mkdirp": "^2.1.3",
     "sharp": "^0.33.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,7 +111,7 @@ async function run(): Promise<void> {
       await download(image.filename)
     )
 
-    const imagePath = path.join('./', newImageFilename)
+    const imagePath = path.join(dirname, newImageFilename)
     const imageExt = path.extname(image.filename).toLocaleLowerCase()
 
     if (imageExt === '') {
@@ -124,15 +124,13 @@ async function run(): Promise<void> {
         sharp.format.hasOwnProperty(imageType?.ext)
       ) {
         if (imageType.ext === 'gif') {
-          await sharp(`./${newImageFilename}`, {
+          await sharp(imagePath, {
             limitInputPixels: false,
             animated: true,
             density: 1
-          }).toFile(`newImageFilename.${imageType.ext}`)
+          }).toFile(`${imagePath}.${imageType.ext}`)
         } else {
-          await sharp(`./${newImageFilename}`).toFile(
-            `newImageFilename.${imageType.ext}`
-          )
+          await sharp(imagePath).toFile(`${imagePath}.${imageType.ext}`)
         }
         newImageFilename += `.${imageType.ext}`
         fs.unlinkSync(imagePath)


### PR DESCRIPTION
안녕하세요 은재님! 
깃에서 이미지를 업로드할 때 저장되는 주소가 변경된거같습니다.
```
//전
https://user-images.githubusercontent.com/adfadsf.JPG

//후
https://github.com/JEM1224/blog/assets/101504594/dfc2ae84-0793-40ec-9152-984664d21289`
```
파일이 버퍼로 저장돼서 버퍼 형태를 이미지로 변경하는 코드를 추가했습니다.


- 이미지 변환을 위한 sharp 패키지를 추가했습니다.

```javascript
    const validExtensionsRegex = /\.(jpg|jpeg|png)$/i

    if (!validExtensionsRegex.test(image.filename)) {
      await sharp(`./${newImageFilename}`)
        .toFormat('png')
        .toFile(`${newImageFilename}.png`)
      const dirpath = path.join(dirname, newImageFilename)
      newImageFilename += '.png'
      fs.unlinkSync(dirpath)
    }
```
- 확장자가 없는 경우 버퍼 파일로 생각해 이미지 변환을 했습니다.
-  `newImageFilename`에 확장자를 추가했습니다.
-  `fs.unlinkSync`을 사용하여 원본 파일을 삭제했습니다.

 기여를 처음해보는지라 틀린 점이 있다면 말씀해 주세요 ! 유튜브 너무 잘보고있습니다 !! 🙇‍♀️
